### PR TITLE
Add !global support

### DIFF
--- a/_sass-import-once.scss
+++ b/_sass-import-once.scss
@@ -1,7 +1,7 @@
 $modules: () !default;
 @mixin exports($name) {
   @if (index($modules, $name) == false) {
-    $modules: append($modules, $name);
+    $modules: append($modules, $name) !global;
     @content;
   }
 }


### PR DESCRIPTION
As discussed in #5 this allows for error and warning free compilation on Sass >= 3.3
