### PR TITLE
Fix for BC break introduced in Sass 3.3.0rc3

### DIFF
--- a/_sass-import-once.scss
+++ b/_sass-import-once.scss
@@ -1,6 +1,6 @@
 $modules: () !default;
 @mixin exports($name) {
-  @if (index($modules, $name) == false) {
+  @if not index($modules, $name) {
     $modules: append($modules, $name) !global;
     @content;
   }


### PR DESCRIPTION
The latest Sass master introduces a BC break with the return value of `index` breaking `export`.

The break in question was introduced here https://github.com/nex3/sass/commit/79bad1ff473cc06c66b85086403f4a1905938e37

This patch fixes the issues maintaining compatibility with 3.3.0rc2 and below.  

This fixes #7.
