### PR TITLE
Fix for !global for the latest update

### DIFF
--- a/_sass-import-once.scss
+++ b/_sass-import-once.scss
@@ -1,4 +1,4 @@
-$modules: () !default;
+$modules: () !global !default;
 @mixin exports($name) {
   @if not index($modules, $name) {
     $modules: append($modules, $name) !global;


### PR DESCRIPTION
Patch for the following warning in Sass 3.3_rc4.

```
Assigning to global variable "$modules" by default is deprecated.
In future versions of Sass, this will create a new local variable.
If you want to assign to the global variable, use "$modules: () !global !default" instead.
```
