### PR TITLE
Add support for node-sass

### DIFF
--- a/_sass-import-once.scss
+++ b/_sass-import-once.scss
@@ -1,6 +1,6 @@
 $modules: () !default;
 @mixin exports($name) {
-  @if (not index($modules, $name)) {
+  @if (index($modules, $name) == null) {
     $modules: append($modules, $name) !global;
     @content;
   }


### PR DESCRIPTION
It appears that node-sass doesn't treat `null` values as falsey.
